### PR TITLE
Fix Laravel Prompts compatibility for Laravel Zero framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "jordanpartridge/github-client": "^2.0.0",
         "illuminate/console": "^11.0",
         "illuminate/collections": "^11.0",
-        "laravel/prompts": "^0.1",
+        "laravel/prompts": "^0.1|^0.3",
         "nesbot/carbon": "^3.0",
         "symfony/console": "^6.0|^7.0"
     },


### PR DESCRIPTION
## Summary
- Expands `laravel/prompts` constraint from `^0.1` to `^0.1|^0.3`
- Resolves dependency conflict with Laravel Zero framework
- Enables github-zero v1.1.0 to work with Laravel Zero projects

## Problem
The current v1.1.0 release has a dependency conflict:
- `github-zero v1.1.0` requires `laravel/prompts ^0.1`
- `laravel-zero/framework` requires `laravel/prompts ^0.3.1`

This prevents users from updating to the latest github-zero version in Laravel Zero projects like Conduit.

## Solution
Updated the constraint to `^0.1|^0.3` to maintain backward compatibility while supporting newer Laravel Zero installations.

## Test plan
- [x] Verify composer.json syntax is valid
- [ ] Test installation in Laravel Zero project
- [ ] Confirm all existing functionality works with both prompt versions

🤖 Generated with [Claude Code](https://claude.ai/code)